### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/modousalla06/5ad92215-c3d8-4ed7-b254-2bedfe7868f0/e57773dc-1978-46ab-b571-fd1a5c4cae89/_apis/work/boardbadge/8954ec32-4337-483f-b2b0-dd4f5ce02f23)](https://dev.azure.com/modousalla06/5ad92215-c3d8-4ed7-b254-2bedfe7868f0/_boards/board/t/e57773dc-1978-46ab-b571-fd1a5c4cae89/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/modousalla06/5ad92215-c3d8-4ed7-b254-2bedfe7868f0/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.